### PR TITLE
Azure: raise FileNotFoundError when requested blob is missing from storage

### DIFF
--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -255,6 +255,8 @@ class AzureStorage(BaseStorage):
         return _get_valid_path(self._normalize_name(clean_name(name)))
 
     def _open(self, name, mode="rb"):
+        if not self.exists(name):
+            raise FileNotFoundError('File does not exist: %s' % name)
         return AzureStorageFile(name, mode, self)
 
     def get_available_name(self, name, max_length=_AZURE_NAME_MAX_LEN):

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -502,3 +502,13 @@ class AzureStorageTest(TestCase):
                 "https://foo_name.blob.core.windows.net",
                 credential={"account_name": "foo_name", "account_key": "foo_key"},
             )
+
+    def test_missing_file_handling(self):
+        client_mock = mock.MagicMock()
+        client_mock.exists.side_effect = [True, False]
+        self.storage._client.get_blob_client.return_value = client_mock
+
+        file_that_exists = self.storage._open('file-that-exists')
+        self.assertIsInstance(file_that_exists, azure_storage.AzureStorageFile)
+
+        self.assertRaises(FileNotFoundError, self.storage._open, 'file-that-does-not-exist')


### PR DESCRIPTION
(This is a duplicate of https://github.com/jschneier/django-storages/pull/1358 made against the canonical project repo.)

This PR implements behaviour in `AzureStorage._open` similar to that [already found in](https://github.com/jschneier/django-storages/blob/master/storages/backends/s3.py#L475) `S3Storage._open`, raising a `FileNotFoundError` if the blob doesn't exist in the storage.